### PR TITLE
Insert address and select delivery option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Added
+
+- `insertAddress` function that calls `EstimateShipping` mutation in order to get available delivery options.
+- `selectDeliveryOption` function that sets the current selected delivery option.
+
 ## [0.1.0] - 2019-09-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `insertAddress` function that calls `EstimateShipping` mutation in order to get available delivery options.
 - `selectDeliveryOption` function that sets the current selected delivery option.
+- Use `useQueueStatus` from `OrderQueue`.
 
 ## [0.1.0] - 2019-09-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `insertAddress` function that calls `EstimateShipping` mutation in order to get available delivery options.
 - `selectDeliveryOption` function that sets the current selected delivery option.
 - Use `useQueueStatus` from `OrderQueue`.
+- `enqueueTask` function that calls `enqueue` from `OrderQueue`.
 
 ## [0.1.0] - 2019-09-23
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,3 +3,68 @@
 > Centralizes all shipping related requests to the Checkout API.
 
 Any kind of shipping query or manipulation should be made through this component. This ensures that each interaction with the Checkout API happens in succession, avoiding concurrency issues.
+
+## Usage
+
+Use the function `useOrderShipping` to get access to the API methods. Your component must be contained in a `OrderShippingProvider`, which in turn must be contained in a `OrderFormProvider` inside a `OrderQueueProvider`.
+
+```tsx
+import { OrderFormProvider } from 'vtex.order-manager/OrderForm'
+import { OrderQueueProvider } from 'vtex.order-manager/OrderQueue'
+import {
+  OrderShippingProvider,
+  useOrderShipping,
+} from 'vtex.order-shipping/OrderShipping'
+
+const MainComponent: FunctionComponent = () => (
+  <OrderQueueProvider>
+    <OrderFormProvider>
+      <OrderShippingProvider>
+        <MyComponent />
+      </OrderShippingProvider>
+    </OrderFormProvider>
+  </OrderQueueProvider>
+)
+
+const MyComponent: FunctionComponent = () => {
+  const { insertAddress, selectDeliveryOption } = useOrderShipping()
+  // ...
+}
+```
+
+## API
+
+### `insertAddress: (props: { addressId: string, addressType: string, city: string, country: string, state: string, street: string, postalCode: string, neighborhood: string, geocoordinates: number[], number: string, complement: string, receiverName: string, reference: string, addressQuery: string}) => void`
+
+Sets the `selectedAddress` inside `shipping` property of the `orderForm`.
+
+#### Example
+
+```tsx
+insertAddress({
+  addressId: '1569522356557',
+  addressType: 'residential',
+  city: 'Rio de Janeiro',
+  country: 'BRA',
+  state: 'RJ',
+  street: 'Rua General Polidoro',
+  postalCode: '22230-060',
+  neighborhood: 'Botafogo',
+  geocoordinates: [],
+  complement: '',
+  number: '',
+  receiverName: '',
+  reference: '',
+  addressQuery: '',
+})
+```
+
+### `selectDeliveryOption: ( deliveryOptionId: string ) => void`
+
+Changes the selected delivery option to be the one which has the given `deliveryOptionId`.
+
+#### Example
+
+```tsx
+selectDeliveryOption('PAC')
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ Any kind of shipping query or manipulation should be made through this component
 
 ## Usage
 
-Use the function `useOrderShipping` to get access to the API methods. Your component must be contained in a `OrderShippingProvider`, which in turn must be contained in a `OrderFormProvider` inside a `OrderQueueProvider`.
+Use the hook `useOrderShipping` to get access to the API methods. Your component must be contained in a `OrderShippingProvider`, which in turn must be contained in a `OrderFormProvider` inside a `OrderQueueProvider`.
 
 ```tsx
 import { OrderFormProvider } from 'vtex.order-manager/OrderForm'

--- a/react/OrderShipping.tsx
+++ b/react/OrderShipping.tsx
@@ -18,9 +18,9 @@ import {
 interface Context {
   countries: string[]
   selectedAddress: CheckoutAddress
-  insertAddress: any
+  insertAddress: (address: CheckoutAddress) => void
   deliveryOptions: DeliveryOption[]
-  selectDeliveryOption: any
+  selectDeliveryOption: (option: string) => void
 }
 
 interface OrderShippingProps {

--- a/react/OrderShipping.tsx
+++ b/react/OrderShipping.tsx
@@ -17,9 +17,9 @@ import {
 
 interface Context {
   countries: string[]
-  selectedAddress: any
+  selectedAddress: CheckoutAddress
   insertAddress: any
-  deliveryOptions: any
+  deliveryOptions: DeliveryOption[]
   selectDeliveryOption: any
 }
 
@@ -99,7 +99,7 @@ export const OrderShippingProvider = compose(
     })
 
     const insertAddress = useCallback(
-      (address: any) => {
+      (address: CheckoutAddress) => {
         const task = async () => {
           const {
             data: { estimateShipping: newOrderForm },

--- a/react/OrderShipping.tsx
+++ b/react/OrderShipping.tsx
@@ -31,16 +31,20 @@ interface OrderShippingProps {
 
 const OrderShippingContext = createContext<Context | undefined>(undefined)
 
-const shippingId = 'shipping'
+const shippingId = 'Shipping'
 
-const getNewDeliveryOptions = (
+const PENDING = 'Pending'
+const FULFILLED = 'Fulfilled'
+const TASK_CANCELLED = 'TASK_CANCELLED'
+
+const changeSelectedDeliveryOption = (
   deliveryOptions: DeliveryOption[],
-  selectedDeliveryOption: string
+  selectedDeliveryOptionId: string
 ) => {
   return deliveryOptions.map(option => {
     if (option.isSelected) {
       option.isSelected = false
-    } else if (option.id === selectedDeliveryOption) {
+    } else if (option.id === selectedDeliveryOptionId) {
       option.isSelected = true
     }
 
@@ -50,7 +54,7 @@ const getNewDeliveryOptions = (
 
 const updateShipping = (totalizers: Totalizer[], newShippingValue: number) => {
   return totalizers.map(totalizer => {
-    if (totalizer.id === 'Shipping') {
+    if (totalizer.id === shippingId) {
       totalizer.value = newShippingValue
     }
     return totalizer
@@ -59,7 +63,7 @@ const updateShipping = (totalizers: Totalizer[], newShippingValue: number) => {
 
 const getShipping = (totalizers: Totalizer[]) => {
   return totalizers.find(totalizer => {
-    return totalizer.id === 'Shipping'
+    return totalizer.id === shippingId
   })
 }
 
@@ -90,11 +94,11 @@ export const OrderShippingProvider = compose(
 
     const isQueueBusy = useRef(false)
     useEffect(() => {
-      const unlisten = listen('Pending', () => (isQueueBusy.current = true))
+      const unlisten = listen(PENDING, () => (isQueueBusy.current = true))
       return unlisten
     })
     useEffect(() => {
-      const unlisten = listen('Fulfilled', () => (isQueueBusy.current = false))
+      const unlisten = listen(FULFILLED, () => (isQueueBusy.current = false))
       return unlisten
     })
 
@@ -119,7 +123,7 @@ export const OrderShippingProvider = compose(
             }
           })
           .catch((error: any) => {
-            if (!error || error.code !== 'TASK_CANCELLED') {
+            if (!error || error.code !== TASK_CANCELLED) {
               throw error
             }
           })
@@ -145,7 +149,7 @@ export const OrderShippingProvider = compose(
           ...orderForm,
           shipping: {
             ...orderForm.shipping,
-            deliveryOptions: getNewDeliveryOptions(
+            deliveryOptions: changeSelectedDeliveryOption(
               deliveryOptions,
               deliveryOptionId
             ),
@@ -173,7 +177,7 @@ export const OrderShippingProvider = compose(
             }
           })
           .catch((error: any) => {
-            if (!error || error.code !== 'TASK_CANCELLED') {
+            if (!error || error.code !== TASK_CANCELLED) {
               throw error
             }
           })

--- a/react/OrderShipping.tsx
+++ b/react/OrderShipping.tsx
@@ -96,11 +96,11 @@ export const OrderShippingProvider = compose(
     useEffect(() => {
       const unlisten = listen(PENDING, () => (isQueueBusy.current = true))
       return unlisten
-    })
+    }, [listen])
     useEffect(() => {
       const unlisten = listen(FULFILLED, () => (isQueueBusy.current = false))
       return unlisten
-    })
+    }, [listen])
 
     const insertAddress = useCallback(
       (address: CheckoutAddress) => {

--- a/react/OrderShipping.tsx
+++ b/react/OrderShipping.tsx
@@ -1,30 +1,201 @@
-import React, { createContext, ReactNode, useContext } from 'react'
-
+import React, {
+  createContext,
+  ReactNode,
+  useContext,
+  useCallback,
+  useEffect,
+  useRef,
+} from 'react'
+import { compose, graphql } from 'react-apollo'
+import { useOrderQueue } from 'vtex.order-manager/OrderQueue'
 import { useOrderForm } from 'vtex.order-manager/OrderForm'
+
+import {
+  estimateShipping as EstimateShipping,
+  selectDeliveryOption as SelectDeliveryOption,
+} from 'vtex.checkout-resources/Mutations'
 
 interface Context {
   countries: string[]
+  selectedAddress: any
+  insertAddress: any
+  deliveryOptions: any
+  selectDeliveryOption: any
 }
 
 interface OrderShippingProps {
   children: ReactNode
+  EstimateShipping: any
+  SelectDeliveryOption: any
 }
 
 const OrderShippingContext = createContext<Context | undefined>(undefined)
 
-export const OrderShippingProvider = ({ children }: OrderShippingProps) => {
-  const {
-    orderForm: {
-      shipping: { countries },
-    },
-  } = useOrderForm()
+const shippingId = 'shipping'
 
-  return (
-    <OrderShippingContext.Provider value={{ countries }}>
-      {children}
-    </OrderShippingContext.Provider>
-  )
+const getNewDeliveryOptions = (
+  deliveryOptions: DeliveryOption[],
+  selectedDeliveryOption: string
+) => {
+  return deliveryOptions.map(option => {
+    if (option.isSelected) {
+      option.isSelected = false
+    } else if (option.id === selectedDeliveryOption) {
+      option.isSelected = true
+    }
+
+    return option
+  })
 }
+
+const updateShipping = (totalizers: Totalizer[], newShippingValue: number) => {
+  return totalizers.map(totalizer => {
+    if (totalizer.id === 'Shipping') {
+      totalizer.value = newShippingValue
+    }
+    return totalizer
+  })
+}
+
+const getShipping = (totalizers: Totalizer[]) => {
+  return totalizers.find(totalizer => {
+    return totalizer.id === 'Shipping'
+  })
+}
+
+const findDeliveryOptionById = (
+  deliveryOptions: DeliveryOption[],
+  deliveryOptionId: string
+): DeliveryOption => {
+  return deliveryOptions.find(option => {
+    return option.id === deliveryOptionId
+  })!
+}
+
+export const OrderShippingProvider = compose(
+  graphql(EstimateShipping, { name: 'EstimateShipping' }),
+  graphql(SelectDeliveryOption, { name: 'SelectDeliveryOption' })
+)(
+  ({
+    children,
+    EstimateShipping,
+    SelectDeliveryOption,
+  }: OrderShippingProps) => {
+    const { enqueue, listen } = useOrderQueue()
+    const { orderForm, setOrderForm } = useOrderForm()
+
+    const {
+      shipping: { countries, selectedAddress, deliveryOptions },
+    } = orderForm
+
+    const isQueueBusy = useRef(false)
+    useEffect(() => {
+      const unlisten = listen('Pending', () => (isQueueBusy.current = true))
+      return unlisten
+    })
+    useEffect(() => {
+      const unlisten = listen('Fulfilled', () => (isQueueBusy.current = false))
+      return unlisten
+    })
+
+    const insertAddress = useCallback(
+      (address: any) => {
+        const task = async () => {
+          const {
+            data: { estimateShipping: newOrderForm },
+          } = await EstimateShipping({
+            variables: {
+              addressInput: address,
+            },
+          })
+
+          return newOrderForm
+        }
+
+        enqueue(task, shippingId)
+          .then((newOrderForm: OrderForm) => {
+            if (!isQueueBusy.current) {
+              setOrderForm(newOrderForm)
+            }
+          })
+          .catch((error: any) => {
+            if (!error || error.code !== 'TASK_CANCELLED') {
+              throw error
+            }
+          })
+      },
+      [EstimateShipping, enqueue, setOrderForm]
+    )
+
+    const selectDeliveryOption = useCallback(
+      (deliveryOptionId: string) => {
+        const { price } = findDeliveryOptionById(
+          deliveryOptions,
+          deliveryOptionId
+        )
+
+        const shipping = getShipping(orderForm.totalizers)
+        if (!shipping) {
+          throw new Error('Shipping totalizer not found')
+        }
+
+        const oldShippingPrice = shipping.value
+
+        const newOrderForm = {
+          ...orderForm,
+          shipping: {
+            ...orderForm.shipping,
+            deliveryOptions: getNewDeliveryOptions(
+              deliveryOptions,
+              deliveryOptionId
+            ),
+          },
+          totalizers: updateShipping(orderForm.totalizers, price),
+          value: orderForm.value - oldShippingPrice + price,
+        }
+        setOrderForm(newOrderForm)
+        const task = async () => {
+          const {
+            data: { selectDeliveryOption: newOrderForm },
+          } = await SelectDeliveryOption({
+            variables: {
+              deliveryOptionId: deliveryOptionId,
+            },
+          })
+
+          return newOrderForm
+        }
+
+        enqueue(task, shippingId)
+          .then((newOrderForm: OrderForm) => {
+            if (!isQueueBusy.current) {
+              setOrderForm(newOrderForm)
+            }
+          })
+          .catch((error: any) => {
+            if (!error || error.code !== 'TASK_CANCELLED') {
+              throw error
+            }
+          })
+      },
+      [SelectDeliveryOption, deliveryOptions, enqueue, orderForm, setOrderForm]
+    )
+
+    return (
+      <OrderShippingContext.Provider
+        value={{
+          countries,
+          selectedAddress,
+          insertAddress,
+          deliveryOptions,
+          selectDeliveryOption,
+        }}
+      >
+        {children}
+      </OrderShippingContext.Provider>
+    )
+  }
+)
 
 export const useOrderShipping = () => {
   const context = useContext(OrderShippingContext)

--- a/react/OrderShipping.tsx
+++ b/react/OrderShipping.tsx
@@ -33,8 +33,11 @@ const OrderShippingContext = createContext<Context | undefined>(undefined)
 
 const shippingId = 'Shipping'
 
-const PENDING = 'Pending'
-const FULFILLED = 'Fulfilled'
+const STATUS = {
+  PENDING: 'Pending',
+  FULFILLED: 'Fulfilled',
+}
+
 const TASK_CANCELLED = 'TASK_CANCELLED'
 
 const changeSelectedDeliveryOption = (
@@ -94,11 +97,17 @@ export const OrderShippingProvider = compose(
 
     const isQueueBusy = useRef(false)
     useEffect(() => {
-      const unlisten = listen(PENDING, () => (isQueueBusy.current = true))
+      const unlisten = listen(
+        STATUS.PENDING,
+        () => (isQueueBusy.current = true)
+      )
       return unlisten
     }, [listen])
     useEffect(() => {
-      const unlisten = listen(FULFILLED, () => (isQueueBusy.current = false))
+      const unlisten = listen(
+        STATUS.FULFILLED,
+        () => (isQueueBusy.current = false)
+      )
       return unlisten
     }, [listen])
 

--- a/react/__mocks__/mockOrderForm.ts
+++ b/react/__mocks__/mockOrderForm.ts
@@ -1,0 +1,29 @@
+export const mockOrderForm = {
+  items: [],
+  shipping: {
+    countries: ['BRA'],
+    deliveryOptions: [
+      { id: 'Motoboy', price: 500, estimate: '8d', isSelected: false },
+      { id: 'PAC', price: 1000, estimate: '5d', isSelected: false },
+      { id: 'Expressa', price: 1000, estimate: '7d', isSelected: true },
+    ],
+    selectedAddress: {
+      addressId: '1569522356557',
+      addressType: 'residential',
+      city: 'Rio de Janeiro',
+      complement: '',
+      country: 'BRA',
+      neighborhood: 'Flamengo',
+      number: '',
+      postalCode: '22280-001',
+      receiverName: '',
+      reference: '',
+      state: 'RJ',
+      street: '',
+      geoCoordinates: [],
+    },
+  },
+  marketingData: null,
+  totalizers: [{ id: 'Shipping', value: 0 }],
+  value: 0,
+}

--- a/react/__mocks__/vtex.checkout-resources/Mutations.ts
+++ b/react/__mocks__/vtex.checkout-resources/Mutations.ts
@@ -1,0 +1,38 @@
+import gql from 'graphql-tag'
+
+export const estimateShipping = gql`
+  mutation MockMutation($addressInput: Address) {
+    estimateShipping(addressInput: $addressInput) {
+      shipping {
+        selectedAddress {
+          addressId
+          addressType
+          city
+          complement
+          country
+          neighborhood
+          number
+          postalCode
+          receiverName
+          reference
+          state
+          street
+        }
+      }
+    }
+  }
+`
+export const selectDeliveryOption = gql`
+  mutation MockMutation($deliveryOptionId: String) {
+    selectDeliveryOption(deliveryOptionId: $deliveryOptionId) {
+      shipping {
+        deliveryOptions {
+          id
+          price
+          estimate
+          isSelected
+        }
+      }
+    }
+  }
+`

--- a/react/__mocks__/vtex.order-manager/OrderForm.tsx
+++ b/react/__mocks__/vtex.order-manager/OrderForm.tsx
@@ -1,0 +1,34 @@
+import React, { createContext, FC, useContext, useMemo, useState } from 'react'
+
+import { mockOrderForm } from '../mockOrderForm'
+
+interface Context {
+  loading: boolean
+  orderForm: any
+  setOrderForm: (_: any) => void
+}
+
+const OrderFormContext = createContext<Context | undefined>(undefined)
+
+export const OrderFormProvider: FC = ({ children }: any) => {
+  const [orderForm, setOrderForm] = useState(mockOrderForm)
+
+  const value = useMemo(
+    () => ({
+      loading: false,
+      orderForm,
+      setOrderForm,
+    }),
+    [orderForm]
+  )
+
+  return (
+    <OrderFormContext.Provider value={value}>
+      {children}
+    </OrderFormContext.Provider>
+  )
+}
+
+export const useOrderForm = () => {
+  return useContext(OrderFormContext)
+}

--- a/react/__mocks__/vtex.order-manager/OrderQueue.tsx
+++ b/react/__mocks__/vtex.order-manager/OrderQueue.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, FC, useContext, useMemo } from 'react'
+import React, { createContext, FC, useContext, useMemo, useRef } from 'react'
 
 interface Context {
   enqueue: (_: any) => Promise<any>
@@ -25,4 +25,13 @@ export const OrderQueueProvider: FC = ({ children }: any) => {
 
 export const useOrderQueue = () => {
   return useContext(OrderQueueContext)
+}
+
+export const useQueueStatus = () => {
+  return useRef(QueueStatus.FULFILLED)
+}
+
+export enum QueueStatus {
+  PENDING = 'Pending',
+  FULFILLED = 'Fulfilled',
 }

--- a/react/__mocks__/vtex.order-manager/OrderQueue.tsx
+++ b/react/__mocks__/vtex.order-manager/OrderQueue.tsx
@@ -1,0 +1,28 @@
+import React, { createContext, FC, useContext, useMemo } from 'react'
+
+interface Context {
+  enqueue: (_: any) => Promise<any>
+  listen: () => () => void
+}
+
+const OrderQueueContext = createContext<Context | undefined>(undefined)
+
+export const OrderQueueProvider: FC = ({ children }: any) => {
+  const value = useMemo(
+    () => ({
+      enqueue: async (f: any) => f(),
+      listen: () => () => {},
+    }),
+    []
+  )
+
+  return (
+    <OrderQueueContext.Provider value={value}>
+      {children}
+    </OrderQueueContext.Provider>
+  )
+}
+
+export const useOrderQueue = () => {
+  return useContext(OrderQueueContext)
+}

--- a/react/__tests__/OrderShipping.test.tsx
+++ b/react/__tests__/OrderShipping.test.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useEffect } from 'react'
+import React, { FunctionComponent } from 'react'
 import { act, render, fireEvent } from '@vtex/test-tools/react'
 import {
   estimateShipping as EstimateShipping,

--- a/react/__tests__/OrderShipping.test.tsx
+++ b/react/__tests__/OrderShipping.test.tsx
@@ -186,5 +186,7 @@ describe('OrderShipping', () => {
     })
 
     await act(() => new Promise(resolve => setTimeout(() => resolve())))
+
+    expect(getByText('PAC')).toBeTruthy()
   })
 })

--- a/react/__tests__/OrderShipping.test.tsx
+++ b/react/__tests__/OrderShipping.test.tsx
@@ -1,0 +1,190 @@
+import React, { FunctionComponent, useEffect } from 'react'
+import { act, render, fireEvent } from '@vtex/test-tools/react'
+import {
+  estimateShipping as EstimateShipping,
+  selectDeliveryOption as SelectDeliveryOption,
+} from 'vtex.checkout-resources/Mutations'
+import { OrderFormProvider, useOrderForm } from 'vtex.order-manager/OrderForm'
+import { OrderQueueProvider } from 'vtex.order-manager/OrderQueue'
+
+import { mockOrderForm } from '../__mocks__/mockOrderForm'
+import { OrderShippingProvider, useOrderShipping } from '../OrderShipping'
+
+const mockedAddress = {
+  addressId: '1569522356558',
+  addressType: 'residential',
+  city: 'Rio de Janeiro',
+  complement: '',
+  country: 'BRA',
+  neighborhood: 'Botafogo',
+  number: '',
+  postalCode: '22230-005',
+  receiverName: '',
+  reference: '',
+  state: 'RJ',
+  street: '',
+  geoCoordinates: [],
+}
+
+const mockedDeliveryOptions = [
+  { id: 'Motoboy', price: 500, estimate: '8d', isSelected: false },
+  { id: 'PAC', price: 1000, estimate: '5d', isSelected: true },
+  { id: 'Expressa', price: 1000, estimate: '7d', isSelected: false },
+]
+
+const mockInsertAddressMutation = (
+  args: CheckoutAddress,
+  result: CheckoutAddress
+) => ({
+  request: {
+    query: EstimateShipping,
+    variables: {
+      addressInput: args,
+    },
+  },
+  result: {
+    data: {
+      estimateShipping: {
+        ...mockOrderForm,
+        shipping: {
+          selectedAddress: result,
+        },
+      },
+    },
+  },
+})
+
+const mockSelectDeliveryOptionMutation = (
+  args: string,
+  result: DeliveryOption[]
+) => ({
+  request: {
+    query: SelectDeliveryOption,
+    variables: {
+      deliveryOptionId: args,
+    },
+  },
+  result: {
+    data: {
+      selectDeliveryOption: {
+        ...mockOrderForm,
+        shipping: {
+          deliveryOptions: result,
+        },
+      },
+    },
+  },
+})
+
+describe('OrderShipping', () => {
+  it('should throw when useOrderShipping is used outside a OrderShippingProvider', () => {
+    const oldConsoleError = console.error
+    console.error = () => {}
+
+    const Component: FunctionComponent = () => {
+      useOrderShipping()
+      return <div>foo</div>
+    }
+
+    expect(() => render(<Component />)).toThrow(
+      'useOrderShipping must be used within a OrderShippingProvider'
+    )
+
+    console.error = oldConsoleError
+  })
+
+  it('should change selectedAddress', async () => {
+    const Component: FunctionComponent = () => {
+      const {
+        orderForm: {
+          shipping: {
+            selectedAddress: { postalCode },
+          },
+        },
+      } = useOrderForm()
+      const { insertAddress } = useOrderShipping()
+
+      return (
+        <div>
+          {postalCode}
+          <button onClick={() => insertAddress(mockedAddress)}>mutate</button>
+        </div>
+      )
+    }
+
+    const mockInsertAddress = mockInsertAddressMutation(
+      mockedAddress,
+      mockedAddress
+    )
+
+    const { getByText } = render(
+      <OrderQueueProvider>
+        <OrderFormProvider>
+          <OrderShippingProvider>
+            <Component />
+          </OrderShippingProvider>
+        </OrderFormProvider>
+      </OrderQueueProvider>,
+      { graphql: { mocks: [mockInsertAddress] } }
+    )
+
+    const button = getByText('mutate')
+
+    expect(getByText('22280-001')).toBeTruthy()
+    act(() => {
+      fireEvent.click(button)
+    })
+
+    await act(() => new Promise(resolve => setTimeout(() => resolve())))
+
+    expect(getByText('22230-005')).toBeTruthy()
+  })
+
+  it('should change the selected delivery option', async () => {
+    const Component: FunctionComponent = () => {
+      const {
+        orderForm: {
+          shipping: { deliveryOptions },
+        },
+      } = useOrderForm()
+      const { selectDeliveryOption } = useOrderShipping()
+
+      const { id } = deliveryOptions.find((option: DeliveryOption) => {
+        return option.isSelected
+      })
+
+      return (
+        <div>
+          {id}
+          <button onClick={() => selectDeliveryOption('PAC')}>mutate</button>
+        </div>
+      )
+    }
+
+    const mockSelectDeliveryOptions = mockSelectDeliveryOptionMutation(
+      'PAC',
+      mockedDeliveryOptions
+    )
+
+    const { getByText } = render(
+      <OrderQueueProvider>
+        <OrderFormProvider>
+          <OrderShippingProvider>
+            <Component />
+          </OrderShippingProvider>
+        </OrderFormProvider>
+      </OrderQueueProvider>,
+      { graphql: { mocks: [mockSelectDeliveryOptions] } }
+    )
+
+    expect(getByText('Expressa')).toBeTruthy()
+
+    const button = getByText('mutate')
+
+    act(() => {
+      fireEvent.click(button)
+    })
+
+    await act(() => new Promise(resolve => setTimeout(() => resolve())))
+  })
+})

--- a/react/typings/globals.d.ts
+++ b/react/typings/globals.d.ts
@@ -1,0 +1,72 @@
+interface OrderForm {
+  items: Item[]
+  shipping: Shipping
+  marketingData: MarketingData | null
+  totalizers: Totalizer[]
+  value: number
+}
+
+interface Item {
+  additionalInfo: ItemAdditionalInfo
+  detailUrl: string
+  id: string
+  imageUrl: string
+  listPrice: number
+  measurementUnit: string
+  name: string
+  price: number
+  productId: string
+  quantity: number
+  sellingPrice: number
+  skuName: string
+  skuSpecifications: SKUSpecification[]
+}
+
+interface ItemAdditionalInfo {
+  brandName: string
+}
+
+interface MarketingData {
+  coupon: string
+}
+
+interface SKUSpecification {
+  fieldName: string
+  fieldValues: string[]
+}
+
+interface Totalizer {
+  id: string
+  name: string
+  value: number
+}
+
+interface Shipping {
+  availableAddresses: CheckoutAddress[]
+  countries: string[]
+  deliveryOptions: DeliveryOption[]
+  selectedAddress: CheckoutAddress | null
+}
+
+interface DeliveryOption {
+  id: string
+  price: number
+  estimate: string
+  isSelected: boolean
+}
+
+interface CheckoutAddress {
+  addressType: string
+  receiverName: string
+  addressId: string
+  postalCode: string
+  city: string
+  state: string
+  country: string
+  street: string
+  number: string
+  neighborhood: string
+  complement: string
+  reference: string | null
+  geoCoordinates: number[]
+}


### PR DESCRIPTION
#### What problem is this solving?

`OrderShipping` needs to provide a API for UI components to change and read  `orderForm` `shipping` data. This PR adds insertAddress and selectDeliveryOption to `OrderShipping` API.  

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

```
cd react
yarn test
```

[Workspace](https://ordershipping--vtexgame1.myvtex.com/cart)

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable).](https://app.clubhouse.io/vtex/story/18320/implementar-consumer-do-order-shipping-no-shipping-calculator)
- [x] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->