### PR TITLE
Add canEditData to the data provided by OrderShipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `canEditData` field to the data provided by `order-shipping`.
+
 ## [0.2.1] - 2019-11-19
 
 ### Changed

--- a/react/OrderShipping.tsx
+++ b/react/OrderShipping.tsx
@@ -18,6 +18,7 @@ interface InsertAddressResult {
 
 interface Context {
   countries: string[]
+  canEditData: boolean
   selectedAddress: CheckoutAddress
   insertAddress: (address: CheckoutAddress) => Promise<InsertAddressResult>
   deliveryOptions: DeliveryOption[]
@@ -89,6 +90,7 @@ export const OrderShippingProvider = compose(
     const queueStatusRef = useQueueStatus(listen)
 
     const {
+      canEditData,
       shipping: { countries, selectedAddress, deliveryOptions },
     } = orderForm
 
@@ -178,6 +180,7 @@ export const OrderShippingProvider = compose(
     return (
       <OrderShippingContext.Provider
         value={{
+          canEditData,
           countries,
           selectedAddress,
           insertAddress,


### PR DESCRIPTION
#### Notes

This PR depends on and must be merged after [checkout-resources](https://github.com/vtex-apps/checkout-resources/pull/15).

#### What problem is this solving?

`OrderShipping` now provides `canEditData` info to the UI components.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- Proceed to [Workspace](https://fixskeleton--checkoutio.myvtex.com/cart).
- Verify that edit postal code button isn't available.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable).](https://app.clubhouse.io/vtex/story/27047/remover-a-op%C3%A7%C3%A3o-de-alterar-cep-no-carrinho-quando-usu%C3%A1rio-estiver-identificado)
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->