### PR TITLE
Use new entrypoints for shipping mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Use the separate `default export`s from `vtex.checkout-resources`.
+
 ## [0.3.0] - 2019-12-10
 
 ### Added

--- a/react/OrderShipping.tsx
+++ b/react/OrderShipping.tsx
@@ -7,10 +7,8 @@ import {
 } from 'vtex.order-manager/OrderQueue'
 import { useOrderForm } from 'vtex.order-manager/OrderForm'
 
-import {
-  estimateShipping as EstimateShipping,
-  selectDeliveryOption as SelectDeliveryOption,
-} from 'vtex.checkout-resources/Mutations'
+import EstimateShipping from 'vtex.checkout-resources/MutationEstimateShipping'
+import SelectDeliveryOption from 'vtex.checkout-resources/MutationSelectDeliveryOption'
 
 interface InsertAddressResult {
   success: boolean

--- a/react/__mocks__/vtex.checkout-resources/MutationEstimateShipping.ts
+++ b/react/__mocks__/vtex.checkout-resources/MutationEstimateShipping.ts
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag'
 
-export const estimateShipping = gql`
+export default gql`
   mutation MockMutation($addressInput: Address) {
     estimateShipping(addressInput: $addressInput) {
       shipping {
@@ -17,20 +17,6 @@ export const estimateShipping = gql`
           reference
           state
           street
-        }
-      }
-    }
-  }
-`
-export const selectDeliveryOption = gql`
-  mutation MockMutation($deliveryOptionId: String) {
-    selectDeliveryOption(deliveryOptionId: $deliveryOptionId) {
-      shipping {
-        deliveryOptions {
-          id
-          price
-          estimate
-          isSelected
         }
       }
     }

--- a/react/__mocks__/vtex.checkout-resources/MutationSelectDeliveryOption.ts
+++ b/react/__mocks__/vtex.checkout-resources/MutationSelectDeliveryOption.ts
@@ -1,0 +1,16 @@
+import gql from 'graphql-tag'
+
+export default gql`
+  mutation MockMutation($deliveryOptionId: String) {
+    selectDeliveryOption(deliveryOptionId: $deliveryOptionId) {
+      shipping {
+        deliveryOptions {
+          id
+          price
+          estimate
+          isSelected
+        }
+      }
+    }
+  }
+`

--- a/react/__tests__/OrderShipping.test.tsx
+++ b/react/__tests__/OrderShipping.test.tsx
@@ -1,9 +1,7 @@
 import React, { FunctionComponent } from 'react'
 import { act, render, fireEvent } from '@vtex/test-tools/react'
-import {
-  estimateShipping as EstimateShipping,
-  selectDeliveryOption as SelectDeliveryOption,
-} from 'vtex.checkout-resources/Mutations'
+import EstimateShipping from 'vtex.checkout-resources/MutationEstimateShipping'
+import SelectDeliveryOption from 'vtex.checkout-resources/MutationSelectDeliveryOption'
 import { OrderFormProvider, useOrderForm } from 'vtex.order-manager/OrderForm'
 import { OrderQueueProvider } from 'vtex.order-manager/OrderQueue'
 

--- a/react/package.json
+++ b/react/package.json
@@ -26,7 +26,7 @@
     "eslint-config-vtex-react": "^4.1.0",
     "prettier": "^1.18.2",
     "tslint-eslint-rules": "^5.4.0",
-    "typescript": "3.5.2"
+    "typescript": "3.7.3"
   },
   "version": "0.3.0"
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5155,10 +5155,10 @@ type-fest@^0.5.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.5.2.tgz#d6ef42a0356c6cd45f49485c3b6281fc148e48a2"
   integrity sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==
 
-typescript@3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
-  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
+typescript@3.7.3:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
+  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
 
 typescript@^3.3.3333:
   version "3.5.3"


### PR DESCRIPTION
#### What problem is this solving?

We are avoiding importing huge `default export`s with multiple GraphQL queries/mutations because that hinders performance. This PR changes `order-shipping` to use the separate `default export`s from `checkout-resources`, which exports just a single query/mutation.

#### How should this be manually tested?

`yarn test` and [this workspace](https://split--checkoutio.myvtex.com)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/31936/mudar-orquestradores-para-usarem-os-novos-entrypoints-de-queries-e-mutations-do-checkout-resources).
- [x] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
