### PR TITLE
CHK-98: Add searchedAddress to context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `searchedAddress` field to the `OrderShipping` context.
 
 ## [0.4.1] - 2020-04-27
 ### Changed

--- a/react/OrderShipping.tsx
+++ b/react/OrderShipping.tsx
@@ -1,4 +1,10 @@
-import React, { createContext, useContext, useCallback, useMemo } from 'react'
+import React, {
+  createContext,
+  useContext,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react'
 import { useMutation } from 'react-apollo'
 import { OrderQueue, OrderForm } from 'vtex.order-manager'
 import {
@@ -30,6 +36,7 @@ interface SelectAddressResult {
 }
 
 interface Context {
+  searchedAddress: CheckoutAddress | null
   countries: string[]
   canEditData: boolean
   selectedAddress?: CheckoutAddress
@@ -49,6 +56,10 @@ export const OrderShippingProvider: React.FC = ({ children }) => {
   const [estimateShipping] = useMutation(EstimateShippingMutation)
   const [selectDeliveryOption] = useMutation(SelectDeliveryOptionMutation)
   const [updateSelectedAddress] = useMutation(UpdateSelectedAddressMutation)
+  const [
+    searchedAddress,
+    setSearchedAddress,
+  ] = useState<CheckoutAddress | null>(null)
 
   const { enqueue, listen } = useOrderQueue()
   const { orderForm, setOrderForm } = useOrderForm()
@@ -80,6 +91,8 @@ export const OrderShippingProvider: React.FC = ({ children }) => {
         if (queueStatusRef.current === QueueStatus.FULFILLED) {
           setOrderForm(newOrderForm)
         }
+
+        setSearchedAddress(address)
 
         return { success: true, orderForm: newOrderForm as CheckoutOrderForm }
       } catch (error) {
@@ -158,6 +171,7 @@ export const OrderShippingProvider: React.FC = ({ children }) => {
 
   const contextValue = useMemo(
     () => ({
+      searchedAddress,
       canEditData,
       countries: countries as string[],
       selectedAddress: selectedAddress!,
@@ -167,6 +181,7 @@ export const OrderShippingProvider: React.FC = ({ children }) => {
       selectDeliveryOption: handleSelectDeliveryOption,
     }),
     [
+      searchedAddress,
       canEditData,
       countries,
       selectedAddress,


### PR DESCRIPTION
#### What problem is this solving?

This adds a new `autocompletedAddress` prop to the context, with the purpose of saving the value of the delivery address right after the API populated it with the data it managed to retrieve from the given postal code. This will be used solely to keep the editable address fields consistent during the complete address step of the shipping flow.

I think `autocompletedAddress` is a really bad name, and I'm open to suggestions.

#### How should this be manually tested?

Follow the test plan of https://github.com/vtex-apps/checkout-shipping/pull/11.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

