### PR TITLE
CHK-425: Update selectDeliveryOption with optimistic behavior

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@
 
 - [ ] Updated `README.md`.
 - [ ] Updated `CHANGELOG.md`.
-- [ ] Linked this PR to a Clubhouse story (if applicable).
+- [ ] Linked this PR to a Jira story (if applicable).
 - [ ] Updated/created tests (important for bug fixes).
 - [ ] Deleted the workspace after merging this PR (if applicable).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update `selectDeliveryOption` function to optimistically update the
+  orderForm delivery options.
 
 ## [0.5.0] - 2020-07-13
 ### Added

--- a/react/package.json
+++ b/react/package.json
@@ -22,7 +22,7 @@
     "@types/react": "^16.8.10",
     "@vtex/test-tools": "^3.1.0",
     "react-intl": "^4.3.1",
-    "typescript": "3.8.3",
+    "typescript": "3.9.7",
     "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.32.1/public/@types/vtex.checkout-graphql",
     "vtex.checkout-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.28.0/public/@types/vtex.checkout-resources",
     "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.4/public/@types/vtex.order-manager",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5263,7 +5263,12 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.8.3, typescript@^3.7.3:
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+
+typescript@^3.7.3:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
   integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==


### PR DESCRIPTION
#### What problem is this solving?

Updates the function `selectDeliveryOption` to optimistically update the orderForm in memory with the passed `deliveryOptionId` set as the selected delivery option, before enqueueing the request to the GraphQL. With this behavior, we can't return the updated orderForm anymore, since the function needs to be synchronous so the caller won't be blocked waiting for the API response. Although this is technically a breaking change, the call-sites of this function already handle the possibility of an `undefined` orderForm, so it shouldn't break anyone, and I intend on releasing this as a new minor.

#### How should this be manually tested?

[Workspace](https://lucas--checkoutio.myvtex.com/cart/add?sku=289).

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
