### PR TITLE
CHK-544: Fix handlers not returning orderForm on success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Function `selectPickupOption` and `selectDeliveryOption` not returning orderForm on success case.
 
 ## [0.7.0] - 2020-12-02
 ### Added

--- a/react/OrderShipping.tsx
+++ b/react/OrderShipping.tsx
@@ -11,7 +11,7 @@ import {
   OrderForm as CheckoutOrderForm,
   Address as CheckoutAddress,
   DeliveryOption,
-  PickupOption
+  PickupOption,
 } from 'vtex.checkout-graphql'
 import EstimateShippingMutation from 'vtex.checkout-resources/MutationEstimateShipping'
 import SelectDeliveryOptionMutation from 'vtex.checkout-resources/MutationSelectDeliveryOption'
@@ -136,19 +136,23 @@ export const OrderShippingProvider: React.FC = ({ children }) => {
         },
       }))
 
-      enqueue(task, 'selectDeliveryOption').then(newOrderForm => {
-        if (queueStatusRef.current === QueueStatus.FULFILLED) {
-          setOrderForm(newOrderForm)
-        }
-      })
+      return enqueue(task, 'selectDeliveryOption').then(
+        newOrderForm => {
+          if (queueStatusRef.current === QueueStatus.FULFILLED) {
+            setOrderForm(newOrderForm)
+          }
 
-      return { success: true }
+          return { success: true, orderForm: newOrderForm }
+        },
+        () => ({ success: false })
+      )
     },
     [queueStatusRef, selectDeliveryOption, enqueue, setOrderForm]
   )
 
-  const handleSelectPickupOption = useCallback(async (pickupOptionId: string) => {
-    const task = async () => {
+  const handleSelectPickupOption = useCallback(
+    async (pickupOptionId: string) => {
+      const task = async () => {
         const {
           data: { selectPickupOption: updatedOrderForm },
         } = await selectPickupOption({
@@ -169,18 +173,23 @@ export const OrderShippingProvider: React.FC = ({ children }) => {
               ...pickupOption,
               isSelected: pickupOption?.id === pickupOptionId,
             })
-          )
+          ),
         },
       }))
 
-      enqueue(task, 'selectPickupOption').then(newOrderForm => {
-        if (queueStatusRef.current === QueueStatus.FULFILLED) {
-          setOrderForm(newOrderForm)
-        }
-      })
+      return enqueue(task, 'selectPickupOption').then(
+        newOrderForm => {
+          if (queueStatusRef.current === QueueStatus.FULFILLED) {
+            setOrderForm(newOrderForm)
+          }
 
-      return { success: true }
-  }, [queueStatusRef, selectPickupOption, enqueue, setOrderForm])
+          return { success: true, orderForm: newOrderForm }
+        },
+        () => ({ success: false })
+      )
+    },
+    [queueStatusRef, selectPickupOption, enqueue, setOrderForm]
+  )
 
   const handleSelectAddress = useCallback(
     async (address: CheckoutAddress) => {
@@ -237,7 +246,7 @@ export const OrderShippingProvider: React.FC = ({ children }) => {
       deliveryOptions,
       pickupOptions,
       handleSelectDeliveryOption,
-      handleSelectPickupOption
+      handleSelectPickupOption,
     ]
   )
 


### PR DESCRIPTION
#### What problem is this solving?

The `selectDeliveryOption` and `selectPickupOption` weren't returning the updated orderForm on the success scenario.

#### How should this be manually tested?

[Workspace](https://addr--checkoutio.myvtex.com/cart/add?sku=289).

You can see that after selecting one delivery option in the shipping step, the next screen correctly shows the selected delivery option

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
